### PR TITLE
add DP0.1 vs DP0.2 comparison notebook in new directory

### DIFF
--- a/DP01_DP02_comparison/Compare_DP01_DP02_object_catalogs.ipynb
+++ b/DP01_DP02_comparison/Compare_DP01_DP02_object_catalogs.ipynb
@@ -1,0 +1,631 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "Author's name: Rachel Mandelbaum (rmandelb on GitHub)\n",
+    "Date last tested: July 24, 2022\n",
+    "\n",
+    "This notebook illustrates a comparison between the DP0.1 and DP0.2 object catalogs, with two goals:\n",
+    "1. Learning more about how to use the Table Access Protocol (TAP) server and ADQL (Astronomy Data Query Language) to query and retrieve data.\n",
+    "2. Comparing DP0.1 and DP0.2 object catalogs, to understand how differences in the image processing from v19 to v23 of the LSST Science Pipelines may affect the measured object properties.\n",
+    "\n",
+    "Attribution: the elements of this notebook that involve learning how to query the object catalogs are heavily based on <a href=\"https://github.com/rubin-dp0/tutorial-notebooks/blob/main/02_Catalog_Queries_with_TAP.ipynb\">one of the DP0.2 tutorials</a>.  Much of the explanatory text in the early parts of the notebook, before the comparison of DP0.1 and DP0.2 outputs, comes from there.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import general python packages\n",
+    "import time\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas\n",
+    "from pandas.testing import assert_frame_equal\n",
+    "from astropy import units as u\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "\n",
+    "# Import the Rubin TAP service utilities\n",
+    "from lsst.rsp import get_tap_service, retrieve_query\n",
+    "\n",
+    "# To ignore some kinds of warnings\n",
+    "import warnings\n",
+    "from astropy.units import UnitsWarning\n",
+    "\n",
+    "# Cosmetic: just make the plot font sizes a little larger\n",
+    "plt.rcParams.update({'font.size': 16})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "warnings.simplefilter(\"ignore\", category=UnitsWarning)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Explore the DP0.2 schema \n",
+    "\n",
+    "We start by getting an instance of the TAP service, and asserting that it exists, as in the tutorial linked in the header."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "service = get_tap_service()\n",
+    "assert service is not None\n",
+    "assert service.baseurl == \"https://data.lsst.cloud/api/tap\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Schema discovery\n",
+    "\n",
+    "To find out what schemas, tables and columns exist, query the Rubin TAP schema.\n",
+    "\n",
+    "This information is also available in the \"Data Products Definitions\" section of the <a href=\"dp0-2.lsst.io\">DP0.2 documentation</a>.\n",
+    "\n",
+    "Create the query to find out what schemas are in the Rubin TAP_SCHEMA, execute it, and see that a TAP Results object is returned.\n",
+    "\n",
+    "This is pretty important because the schemas have changed considerably from DP0.1 to DP0.2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"SELECT * FROM tap_schema.schemas\"\n",
+    "results = service.search(query)\n",
+    "print(type(results))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Convert the results to an astropy table and display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = service.search(query).to_table()\n",
+    "results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.3. The DP0.2 catalogs\n",
+    "\n",
+    "All the DP0 tables (catalogs) are in the \"dp02_dc2_catalogs\" schema (table collection).\n",
+    "\n",
+    "Search for the DP0 schema name and store as a variable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "schema_names = results['schema_name']\n",
+    "for name in schema_names:\n",
+    "    if name.find('dp01') > -1:\n",
+    "        dp01_schema_name = name\n",
+    "        break\n",
+    "print(\"DP0.1 schema is \" + dp01_schema_name)\n",
+    "for name in schema_names:\n",
+    "    if name.find('dp02') > -1:\n",
+    "        dp02_schema_name = name\n",
+    "        break\n",
+    "print(\"DP0.2 schema is \" + dp02_schema_name)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's explore tables in the DP0.1 and DP0.2 schema, ordering them by their database.\n",
+    "This is the order in which they will appear presented to the user in the RSP Portal.\n",
+    "We see the tables in the DP0.1 and DP0.2 schema, the same tables that are presented via the Portal GUI, together with a description of each. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query1 = \"SELECT * FROM tap_schema.tables \" \\\n",
+    "        \"WHERE tap_schema.tables.schema_name = '\" \\\n",
+    "        + dp01_schema_name + \"' order by table_index ASC\"\n",
+    "print(query1)\n",
+    "query2 = \"SELECT * FROM tap_schema.tables \" \\\n",
+    "        \"WHERE tap_schema.tables.schema_name = '\" \\\n",
+    "        + dp02_schema_name + \"' order by table_index ASC\"\n",
+    "print(query2)\n",
+    "\n",
+    "results1 = service.search(query1)\n",
+    "results1 = results1.to_table()\n",
+    "results2 = service.search(query2)\n",
+    "results2 = results2.to_table()\n",
+    "results2\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Querying the DP0.1 and DP0.2 Object catalog\n",
+    "\n",
+    "The Object catalogs (e.g., dp02_dc2_catalogs.Object) contain sources detected in the coadded images.\n",
+    "\n",
+    "### 3.1. Getting the columns available for a given table\n",
+    "\n",
+    "Request the column names, data types, descriptions, and units for all columns in the Object catalog, and display as a Pandas table (which will automatically truncate)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results1 = service.search(\"SELECT column_name, datatype, description, unit from TAP_SCHEMA.columns \"\n",
+    "                         \"WHERE table_name = 'dp01_dc2_catalogs.Object'\")\n",
+    "results1.to_table().to_pandas()\n",
+    "results2 = service.search(\"SELECT column_name, datatype, description, unit from TAP_SCHEMA.columns \"\n",
+    "                         \"WHERE table_name = 'dp02_dc2_catalogs.Object'\")\n",
+    "results2.to_table().to_pandas()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There is no need to read through all the columns, which are also available in the \"Data Products Definitions\" section of the <a href=\"dp0-2.lsst.io\">DP0.2 documentation</a>.\n",
+    "\n",
+    "The output of the next cell was used to identify the different column names for some of the information of interest in the DP0.1 and DP0.2 schema."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(results1['column_name'])\n",
+    "print(results2['column_name'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Clean up."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del results1,results2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cone search\n",
+    "\n",
+    "A cone search on the Object table will be a common TAP query.\n",
+    "In this example, a circle centered on (RA, Dec) = (62.0, -37.0), with a radius of 0.2 degrees is used.  This area was chosen because it contains a reasonably large number of objects (around 40k) yet the queries still run in a 1 to several seconds.\n",
+    "\n",
+    "Define the central coordinates and search radius using AstroPy `SkyCoord` and units."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "center_coords = SkyCoord(62, -37, frame='icrs', unit='deg')\n",
+    "search_radius = 0.2*u.deg\n",
+    "\n",
+    "print(center_coords)\n",
+    "print(search_radius)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The TAP queries take the center coordinates and the search radius -- both in units of degrees -- as strings, so also define strings to use in the query statements below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "use_center_coords = \"62, -37\"\n",
+    "use_radius = \"0.2\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Build and execute the query\n",
+    "\n",
+    "Build queries to find objects down to a limiting magnitude of i<26, with basic flags set, in both the DP0.1 and DP0.2 object catalogs.  Note that not only column names differ; the manner of setting magnitude cuts, and the table names (object vs. Object) also differ.\n",
+    "\n",
+    "In DP0.2 it is recommended to set `detect_isPrimary = True` (which means the source has no deblended children, to avoid returning both deblended *and* blended objects); in DP0.1 we use the clean flag.\n",
+    "\n",
+    "Execute the queries; the two searches combined usually take about 5-10 seconds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "query1 = \"SELECT  \" + \\\n",
+    "        \"objectId, ra, dec, clean, \" + \\\n",
+    "        \"mag_i_cModel, mag_g_cModel, psf_fwhm_i, extendedness, blendedness \" + \\\n",
+    "        \"FROM dp01_dc2_catalogs.object \" + \\\n",
+    "        \"WHERE CONTAINS(POINT('ICRS', ra, dec), \" + \\\n",
+    "        \"CIRCLE('ICRS', \" + use_center_coords + \", \" + use_radius + \")) = 1 \" + \\\n",
+    "        \"AND clean = 1 \" + \\\n",
+    "        \"AND mag_i_cModel < 26.0\"\n",
+    "results1 = service.search(query1)\n",
+    "print('DP0.1 query returned ',len(results1))\n",
+    "\n",
+    "query2 = \"SELECT  \" + \\\n",
+    "        \"objectId, coord_ra, coord_dec, detect_isPrimary, detect_isIsolated, \" + \\\n",
+    "        \"i_cModelFlux, g_cModelFlux, i_inputCount, i_fwhm, i_extendedness, i_blendedness, \" + \\\n",
+    "        \"scisql_nanojanskyToAbMag(i_cModelFlux) as mag_i_cModel, \" + \\\n",
+    "        \"scisql_nanojanskyToAbMag(g_cModelFlux) as mag_g_cModel \" + \\\n",
+    "        \"FROM dp02_dc2_catalogs.Object \" + \\\n",
+    "        \"WHERE CONTAINS(POINT('ICRS', coord_ra, coord_dec), \" + \\\n",
+    "        \"CIRCLE('ICRS', \" + use_center_coords + \", \" + use_radius + \")) = 1 \" + \\\n",
+    "        \"AND detect_isPrimary = 1 \" + \\\n",
+    "        \"AND scisql_nanojanskyToAbMag(i_cModelFlux) < 26.0\"\n",
+    "results2 = service.search(query2)\n",
+    "print('DP0.2 query returned ',len(results2))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Start to compare properties\n",
+    "\n",
+    "We're going to start comparing object properties in DP0.1 vs. DP0.2.  To begin with, we just look at ensemble properties of the populations detected in this region, without matching on a per-object basis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define a utility that will let us look at a 2D histogram of object positions on the sky.\n",
+    "def show_radec(ra, dec, bins=30, title=None):\n",
+    "    plt.hist2d(ra, dec, bins)\n",
+    "    plt.gca().set_aspect('equal')\n",
+    "    plt.xlabel('RA [deg]')\n",
+    "    plt.ylabel('dec [deg]')\n",
+    "    if title is not None: plt.title(title)\n",
+    "    plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll look at 2D histograms of object positions in DP0.1 and DP0.2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot a 2d histogram of object positions, noting different column names for coordinate positions.\n",
+    "plt.figure(figsize=(15,7))\n",
+    "plt.subplot(121)\n",
+    "show_radec(results1['ra'], results1['dec'], title='DP0.1')\n",
+    "plt.subplot(122)\n",
+    "show_radec(results2['coord_ra'], results2['coord_dec'], title='DP0.2')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Observations:\n",
+    "\n",
+    "1. The images look similar, in the sense that they have similar high/low points.\n",
+    "2. But they are not identical.  This is probably expected since we put a magnitude cut, and some objects may scatter across that limit due to differences in the image processing.\n",
+    "\n",
+    "Next we will look at histograms of the g-i cmodel colors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(6,6))\n",
+    "plt.subplot(111)\n",
+    "plt.hist(results1['mag_g_cModel']-results1['mag_i_cModel'], 30, range=[-2,6], density=True, histtype='step', label='DP0.1')\n",
+    "plt.hist(results2['mag_g_cModel']-results2['mag_i_cModel'], 30, range=[-2,6], density=True, histtype='step', label='DP0.2')\n",
+    "plt.xlabel('g-i cmodel color')\n",
+    "plt.yscale('log')\n",
+    "plt.legend(loc='upper right')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These look very similar!  Now we'll do the same for the i-band magnitudes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(6,6))\n",
+    "plt.subplot(111)\n",
+    "plt.hist(results1['mag_i_cModel'], 30, range=[18,26], density=True, histtype='step', label='DP0.1')\n",
+    "plt.hist(results2['mag_i_cModel'], 30, range=[18,26], density=True, histtype='step', label='DP0.2')\n",
+    "plt.xlabel('i-band cmodel magnitude')\n",
+    "plt.yscale('log')\n",
+    "plt.legend(loc='upper left')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These also look very similar.  So at least the basic object properties -- positions, i-band magnitude, g-i color -- for the selected ensemble (40k objects) seem very similar.  We'll move on to comparison of per-object properties, which requires cross-matching.  I wasn't sure if there is a cross-matching routine in the RSP, so I just used astropy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import astropy.units as u\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "c1 = SkyCoord(ra=results1['ra']*u.degree, dec=results1['dec']*u.degree)\n",
+    "c2 = SkyCoord(ra=results2['coord_ra']*u.degree, dec=results2['coord_dec']*u.degree)\n",
+    "max_sep = 1.0 * u.arcsec\n",
+    "idx, d2d, d3d = c1.match_to_catalog_sky(c2)\n",
+    "sep_constraint = d2d < max_sep\n",
+    "def get_matched_columns(cat1, cat2, mask1, mask2, colname1, colname2):\n",
+    "    return cat1[colname1][mask1], cat2[colname2][mask2]\n",
+    "\n",
+    "# We'd like to check the per-object positions, and the i-band magnitudes.\n",
+    "# We'd further like to check these for isolated vs. non-isolated objects (as flagged by Scarlet in DP0.2).\n",
+    "# So we have to get a bunch of matched columns.\n",
+    "# Maybe there is a nice way to get fully reordered Tables but I couldn't get it to work in the time available to me.\n",
+    "matched_ra1, matched_ra2 = get_matched_columns(results1, results2, sep_constraint, idx[sep_constraint], 'ra', 'coord_ra')\n",
+    "matched_dec1, matched_dec2 = get_matched_columns(results1, results2, sep_constraint, idx[sep_constraint], 'dec', 'coord_dec')\n",
+    "matched_imag1, matched_imag2 = get_matched_columns(results1, results2, sep_constraint, idx[sep_constraint], 'mag_i_cModel', 'mag_i_cModel')\n",
+    "_, matched_isolated = get_matched_columns(results1, results2, sep_constraint, idx[sep_constraint], 'mag_g_cModel', 'detect_isIsolated')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We start by comparing the RA and dec values in DP0.2 vs. DP0.1, to look for astrometric offsets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib as mpl\n",
+    "def show_deltaradec(ra1, dec1, ra2, dec2, bins=25, range=(-0.2,0.2), title=None):\n",
+    "    plt.hist2d(3600*(ra2-ra1)*np.cos(dec1*np.pi/180.),\n",
+    "               3600*(dec2-dec1), bins, norm=mpl.colors.LogNorm(),\n",
+    "               range=(range, range))\n",
+    "    plt.gca().set_aspect('equal')\n",
+    "    plt.axvline(0, c='red')\n",
+    "    plt.axhline(0, c='red')\n",
+    "    plt.colorbar(label='Number of objects')\n",
+    "    plt.xlabel(r'($\\Delta$RA)cos(dec) [arcsec]')\n",
+    "    plt.ylabel(r'$\\Delta$dec [arcsec]');\n",
+    "    if title is not None: plt.title(title)\n",
+    "\n",
+    "plt.figure(figsize=(10,7))\n",
+    "show_deltaradec(matched_ra1, matched_dec1, matched_ra2, matched_dec2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Given the log scale on the histogram, we can see that the astrometry agrees very well between DP0.1 and DP0.2.\n",
+    "\n",
+    "Next, we'll explore the i-band cmodel magnitudes.  For this purpose, we'll plot mag(DP0.2)-mag(DP0.1) as a function of mag(DP0.1).  Besides the 2D histogram, we'll show lines for the median and 10th/90th percentiles, so we can quantify any systematic offsets and the spread in the distribution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import scipy.stats\n",
+    "x = matched_imag1\n",
+    "y = matched_imag2 - matched_imag1\n",
+    "x_range = [20, 26]\n",
+    "\n",
+    "# Get running stats for Delta(mag)\n",
+    "def percentile10(y):\n",
+    "   return(np.percentile(y,10))\n",
+    "def percentile90(y):\n",
+    "   return(np.percentile(y,90))\n",
+    "running_median, edges, _ = scipy.stats.binned_statistic(x, y, statistic='median', bins=20, range=x_range)\n",
+    "running_10p, _, _ = scipy.stats.binned_statistic(x, y, statistic=percentile10, bins=20, range=x_range)\n",
+    "running_90p, _, _ = scipy.stats.binned_statistic(x, y, statistic=percentile90, bins=20, range=x_range)\n",
+    "\n",
+    "# Now plot the 2D histogram along with the running stats.\n",
+    "plt.figure(figsize=(10,7))\n",
+    "plt.hist2d(x, y, 30, \n",
+    "           range=[x_range, [-1,1]], norm=mpl.colors.LogNorm())\n",
+    "plt.axhline(0, c='red')\n",
+    "plt.plot(0.5*(edges[1:]+edges[:-1]), running_median, color='cyan', ls='--')\n",
+    "plt.plot(0.5*(edges[1:]+edges[:-1]), running_10p, color='cyan', ls='--')\n",
+    "plt.plot(0.5*(edges[1:]+edges[:-1]), running_90p, color='cyan', ls='--')\n",
+    "plt.colorbar(label='Number of objects')\n",
+    "plt.xlabel(r'i-band cmodel magnitude')\n",
+    "plt.ylabel(r'$\\Delta$mag');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As shown, the median Delta(mag) is very close to 0.  However, the 10th/90th percentiles indicate significant scatter, even though these object catalogs are based on the same image pixels.  Presumably this reflects some evolution in the LSST Science Pipelines detection, selection, deblending, or cmodel magnitude measurement algorithm.\n",
+    "\n",
+    "Following a suggestion from Melissa Graham, I decided to check whether it could be due to the new deblender (Scarlet), by comparing the 10th/90th percentiles and the median for those objects that Scarlet flagged as isolated vs. those that were not. Presumably the isolated ones may not have been deblended in either DP0.1 or DP0.2, so they should agree if the deblender is responsible for the above differences."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_iso = matched_imag1[matched_isolated]\n",
+    "y_iso = matched_imag2[matched_isolated] - matched_imag1[matched_isolated]\n",
+    "x_not_iso = matched_imag1[~matched_isolated]\n",
+    "y_not_iso = matched_imag2[~matched_isolated] - matched_imag1[~matched_isolated]\n",
+    "print('Isolated, non-isolated, and total matched objects:',len(x_iso),len(x_not_iso), len(matched_imag1))\n",
+    "\n",
+    "running_median_iso, edges_iso, _ = scipy.stats.binned_statistic(x_iso, y_iso, statistic='median', bins=10, range=x_range)\n",
+    "running_10p_iso, _, _ = scipy.stats.binned_statistic(x_iso, y_iso, statistic=percentile10, bins=10, range=x_range)\n",
+    "running_90p_iso, _, _ = scipy.stats.binned_statistic(x_iso, y_iso, statistic=percentile90, bins=10, range=x_range)\n",
+    "running_median_not_iso, edges_not_iso, _ = scipy.stats.binned_statistic(x_not_iso, y_not_iso, statistic='median', bins=20, range=x_range)\n",
+    "running_10p_not_iso, _, _ = scipy.stats.binned_statistic(x_not_iso, y_not_iso, statistic=percentile10, bins=20, range=x_range)\n",
+    "running_90p_not_iso, _, _ = scipy.stats.binned_statistic(x_not_iso, y_not_iso, statistic=percentile90, bins=20, range=x_range)\n",
+    "\n",
+    "plt.figure(figsize=(10,7))\n",
+    "plt.plot(0.5*(edges_iso[1:]+edges_iso[:-1]), running_median_iso, color='magenta', label='Isolated')\n",
+    "plt.plot(0.5*(edges_iso[1:]+edges_iso[:-1]), running_10p_iso, color='magenta', ls='--')\n",
+    "plt.plot(0.5*(edges_iso[1:]+edges_iso[:-1]), running_90p_iso, color='magenta', ls='--')\n",
+    "plt.plot(0.5*(edges_not_iso[1:]+edges_not_iso[:-1]), running_median_not_iso, color='blue', label='Not isolated')\n",
+    "plt.plot(0.5*(edges_not_iso[1:]+edges_not_iso[:-1]), running_10p_not_iso, color='blue', ls='--')\n",
+    "plt.plot(0.5*(edges_not_iso[1:]+edges_not_iso[:-1]), running_90p_not_iso, color='blue', ls='--')\n",
+    "#plt.axhline(0, color='black')\n",
+    "plt.xlabel(r'i-band cmodel magnitude')\n",
+    "plt.ylabel(r'$\\Delta$mag')\n",
+    "plt.legend()\n",
+    "plt.ylim((-0.4,0.4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As indicated, 25% of the objects are flagged as isolated.  Those have a very narrow scatter (10th/90th percentiles indicated as dashed lines).  The non-isolated objects have a much broader scatter, suggesting that the differences in cmodel magnitudes from DP0.1 to DP0.2 may be primarily because of the different deblender."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This plot led me to wonder if the astrometric scatter has the same origin, so I remade the astrometry difference plot for isolated vs. non-isolated objects:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(15,7))\n",
+    "plt.subplot(121)\n",
+    "show_deltaradec(matched_ra1[matched_isolated], matched_dec1[matched_isolated],\n",
+    "                matched_ra2[matched_isolated], matched_dec2[matched_isolated],\n",
+    "                title='Isolated')\n",
+    "plt.subplot(122)\n",
+    "show_deltaradec(matched_ra1[~matched_isolated], matched_dec1[~matched_isolated],\n",
+    "                matched_ra2[~matched_isolated], matched_dec2[~matched_isolated],\n",
+    "                title='Not isolated')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "While not a quantitative comparison, visually we can see that the central pixels have similar values for the two cases, but the right plot (non-isolated) has more spread.  So qualitatively, at least, it appears that the difference in deblending may explain a good fraction of the astrometric offsets between detected centroids in the object catalogs."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "LSST",
+   "language": "python",
+   "name": "lsst"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/DP01_DP02_comparison/Compare_DP01_DP02_object_catalogs.ipynb
+++ b/DP01_DP02_comparison/Compare_DP01_DP02_object_catalogs.ipynb
@@ -7,6 +7,7 @@
     "## Introduction\n",
     "\n",
     "Author's name: Rachel Mandelbaum (rmandelb on GitHub)\n",
+    "\n",
     "Date last tested: July 24, 2022\n",
     "\n",
     "This notebook illustrates a comparison between the DP0.1 and DP0.2 object catalogs, with two goals:\n",

--- a/DP01_DP02_comparison/README.md
+++ b/DP01_DP02_comparison/README.md
@@ -1,0 +1,13 @@
+# Comparing DP0.1 and DP0.2 catalogs
+
+Rachel Mandelbaum
+July 24, 2022
+
+This folder is for contributions that compare DP0.1 and DP0.2 catalogs.
+
+Contents:
+
+| Title | Description | Author |
+|---|---|---|
+| Compare_DP01_DP02_object_catalogs.ipynb | Compare DP0.1 and DP0.2 object catalogs - basic properties | Rachel Mandelbaum |
+

--- a/DP01_DP02_comparison/README.md
+++ b/DP01_DP02_comparison/README.md
@@ -1,6 +1,7 @@
 # Comparing DP0.1 and DP0.2 catalogs
 
 Rachel Mandelbaum
+
 July 24, 2022
 
 This folder is for contributions that compare DP0.1 and DP0.2 catalogs.


### PR DESCRIPTION
Adding new notebook comparing DP0.1 and DP0.2 object catalogs.

@MelissaGraham - I wanted to check whether the attribution at the top is sufficient:

> Attribution: the elements of this notebook that involve learning how to query the object catalogs are heavily based on [one of the DP0.2 tutorials](https://github.com/rubin-dp0/tutorial-notebooks/blob/main/02_Catalog_Queries_with_TAP.ipynb). Much of the explanatory text in the early parts of the notebook, before the comparison of DP0.1 and DP0.2 outputs, comes from there.

Is that OK or should I omit text that comes directly from those tutorials?
